### PR TITLE
Fix watchdog import is macos specific

### DIFF
--- a/callback_plugins/beautiful_output.py
+++ b/callback_plugins/beautiful_output.py
@@ -84,7 +84,7 @@ except:
     from collections import Sequence
 from numbers import Number
 from os.path import basename, isdir
-from watchdog.observers.fsevents2 import FSEventsObserver2 as Observer
+from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, EVENT_TYPE_CREATED
 
 _symbol = {


### PR DESCRIPTION
The `watchdog`'s `FSEventsObserver2` import is `MacOS` specific. The project will raise an exception on any linux:

```
ERROR! Unexpected Exception, this is probably a bug: No module named 'AppKit'
the full traceback was:

Traceback (most recent call last):
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/bin/ansible-playbook", line 123, in <module>
    exit_code = cli.run()
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/cli/playbook.py", line 129, in run
    results = pbex.run()
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/executor/playbook_executor.py", line 99, in run
    self._tqm.load_callbacks()
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/executor/task_queue_manager.py", line 136, in load_callbacks
    self._stdout_callback = callback_loader.get(self._stdout_callback)
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/plugins/loader.py", line 792, in get
    return self.get_with_context(name, *args, **kwargs).object
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/plugins/loader.py", line 812, in get_with_context
    self._module_cache[path] = self._load_module_source(name, path)
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/ansible/plugins/loader.py", line 776, in _load_module_source
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/cyrbil/projects/ansible_ks/callback_plugins/beautiful_output.py", line 87, in <module>
    from watchdog.observers.fsevents2 import FSEventsObserver2 as Observer
  File "/home/cyrbil/.asdf/installs/python/3.9.6-ansible/lib/python3.9/site-packages/watchdog/observers/fsevents2.py", line 47, in <module>
    import AppKit
ModuleNotFoundError: No module named 'AppKit'
```

This fix imports `Observer` from `__init__.py` which will load the correct module for the current system.